### PR TITLE
chore(ci): Changes GitHub Actions step to pull previous tag (#23)

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -19,6 +19,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+        with:
+          fetch-depth: 0 # Required due to the way Git works, without it this action won't be able to find any or the correct tags
 
       # https://github.com/marketplace/actions/docker-setup-buildx
       - name: Set up Docker Buildx
@@ -84,12 +86,10 @@ jobs:
           repository: ndigitals/openlitespeed
           short-description: ${{ github.event.repository.description }}
 
-      - name: Get previous tag
+      # https://github.com/marketplace/actions/get-latest-tag
+      - name: Get Latest Tag
         id: previousTag
-        run: |
-          name=$(git --no-pager tag --sort=creatordate --merged ${{ github.ref_name }} | tail -2 | head -1)
-          echo "previousTag: $name"
-          echo "previousTag=$name" >> $GITHUB_ENV
+        uses: WyriHaximus/github-action-get-previous-tag@v1
 
       # https://github.com/marketplace/actions/changelog-from-conventional-commits
       - name: Update CHANGELOG
@@ -98,7 +98,7 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           fromTag: ${{ github.ref_name }}
-          toTag: ${{ env.previousTag }}
+          toTag: ${{ steps.previoustag.outputs.tag }}
           writeToFile: false
 
       # https://github.com/marketplace/actions/conventional-commits-semver-release


### PR DESCRIPTION
- Updates the release steps to properly pull the previous tag for generating the changelog.

