### PR TITLE
chore(ci): Fixes steps restricted to latest release & proper comparison

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -90,21 +90,24 @@ jobs:
       - name: Get Latest Tag
         id: previousTag
         uses: WyriHaximus/github-action-get-previous-tag@v1
+        if: matrix.PHP_VERSION == '8.2.0'
 
       # https://github.com/marketplace/actions/changelog-from-conventional-commits
       - name: Update CHANGELOG
         id: changelog
         uses: requarks/changelog-action@v1
+        if: matrix.PHP_VERSION == '8.2.0'
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          fromTag: ${{ github.ref_name }}
-          toTag: ${{ steps.previoustag.outputs.tag }}
+          fromTag: ${{ steps.previoustag.outputs.tag }}
+          toTag: ${{ github.ref_name }}
           writeToFile: false
 
       # https://github.com/marketplace/actions/conventional-commits-semver-release
-      - name: semver
+      - name: Get Release Version
         id: semver
         uses: grumpy-programmer/conventional-commits-semver-release@v1
+        if: matrix.PHP_VERSION == '8.2.0'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
- Updates the GitHub Actions steps for release to only run on the latest release.
- Updates the GitHub Actions step for generating the changelog to use the proper from & to.
