### PR TITLE
chore(ci): Fixes GitHub Actions matrix job failures & changelog generation (#33)

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -13,6 +13,7 @@ jobs:
   buildx:
     runs-on: self-hosted
     strategy:
+      fail-fast: false
       matrix: 
         PHP_VERSION: ['8.0.26', '8.1.13', '8.2.0']
 
@@ -109,7 +110,7 @@ jobs:
         if: matrix.PHP_VERSION == '8.2.0'
         with:
           previousReleaseTagNameOrSha: ${{ steps.semver.outputs.current }}
-          nextReleaseTagName: ${{ steps.semver.outputs.next }}
+          nextReleaseTagName: 'main'
           nextReleaseName: ${{ steps.release-name.outputs.RELEASE_NAME }}
 
       # https://github.com/marketplace/actions/create-release


### PR DESCRIPTION
* Changes GitHub Actions matrix jobs to not cancel running jobs when one fails.
* Updates the changelog generation to use `main` as the "nextReleaseTagName" for comparison.