### PR TITLE
chore: Adds Dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  - package-ecosystem: "docker" # See documentation for possible values
+    directory: "/templates" # Location of package manifests
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
* Adds the required configuration so that Dependabot can keep the Dockerfile dependencies up-to-date.