### PR TITLE
fix(cron): Fixes bad cron job command for restarting OLS on `.htaccess` file changes

### DIFF
--- a/template/ols_htaccess
+++ b/template/ols_htaccess
@@ -9,4 +9,4 @@ PATH=/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin
 # |  |  |  |  .---- day of week (0 - 6) (Sunday=0 or 7) OR sun,mon,tue,wed,thu,fri,sat
 # |  |  |  |  |
 # *  *  *  *  * user-name command to be executed
-*/3	*	*	*	*	root	if ! find /var/www/vhosts/ -maxdepth 2 -type f -newer /usr/local/lsws/cgid -name '.htaccess' -exec false {} +; then systemctl restart lsws; fi
+*/3	*	*	*	*	root	if ! find /var/www/vhosts/ -maxdepth 5 -type f -newer /usr/local/lsws/cgid -name '.htaccess' -exec false {} +; then service lsws restart; fi


### PR DESCRIPTION
- Updates the cron job to call the correct command to restart the OLS service.
- Updates the maxdepth specified in the OLS restart cron job to ensure that additional `.htaccess` files are found/monitored.
