### PR TITLE
fix(php): Updates PHP 8 to latest releases as of 2023-04-13 (#79)

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -8,7 +8,7 @@ on:
 
 env:
   OLS_VERSION: 1.7.16
-  PHP_STABLE_VERSION: '8.2.3'
+  PHP_STABLE_VERSION: '8.2.5'
   REGISTRY: ghcr.io
 
 jobs:
@@ -17,7 +17,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix: 
-        PHP_VERSION: ['8.0.28', '8.1.16', '8.2.3']
+        PHP_VERSION: ['8.0.28', '8.1.18', '8.2.5']
 
     steps:
       - name: Checkout


### PR DESCRIPTION
- Updates to PHP 8.1.18.
- Updates to PHP 8.2.5.

