### PR TITLE
fix(debian): Updates Docker image build to apply security updates (#84)

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -62,6 +62,7 @@ jobs:
             PHP_MINOR_VERSION=${{ steps.php-version.outputs._1 }}
           push: true
           tags: ${{ env.REGISTRY }}/ndigitals/openlitespeed:${{ env.OLS_VERSION }}-lsphp${{ steps.php-version.outputs._0 }}${{ steps.php-version.outputs._1 }}
+          no-cache: ${{ github.event_name == 'workflow_dispatch' && true || false }}
           cache-from: type=registry,ref=${{ env.REGISTRY }}/ndigitals/openlitespeed:latest
           cache-to: type=inline
 
@@ -82,6 +83,7 @@ jobs:
           tags: |
             ${{ env.REGISTRY }}/ndigitals/openlitespeed:${{ env.OLS_VERSION }}-lsphp${{ steps.php-version.outputs._0 }}${{ steps.php-version.outputs._1 }}
             ${{ env.REGISTRY }}/ndigitals/openlitespeed:latest
+          no-cache: ${{ github.event_name == 'workflow_dispatch' && true || false }}
           cache-from: type=registry,ref=${{ env.REGISTRY }}/ndigitals/openlitespeed:latest
           cache-to: type=inline
 

--- a/template/Dockerfile
+++ b/template/Dockerfile
@@ -3,7 +3,7 @@ ARG PHP_VERSION
 ARG PHP_MAJOR_VERSION
 ARG PHP_MINOR_VERSION
 
-FROM arm64v8/wordpress:cli-php${PHP_MAJOR_VERSION}.${PHP_MINOR_VERSION} AS wp-cli
+FROM wordpress:cli-php${PHP_MAJOR_VERSION}.${PHP_MINOR_VERSION} AS wp-cli
 
 ARG OLS_VERSION
 ARG PHP_VERSION
@@ -12,7 +12,7 @@ ARG PHP_MINOR_VERSION
 
 FROM litespeedtech/openlitespeed:${OLS_VERSION}-lsphp${PHP_MAJOR_VERSION}0 AS ols
 
-FROM arm64v8/debian:11-slim
+FROM debian:11-slim
 
 LABEL org.opencontainers.image.url=https://github.com/ndigitals/ols-dockerfiles
 LABEL org.opencontainers.image.documentation=https://github.com/ndigitals/ols-dockerfiles/wiki
@@ -39,7 +39,8 @@ COPY *.sh /build/
 # References:
 #     - https://www.dajobe.org/blog/2015/04/18/making-debian-docker-images-smaller/
 #     - https://github.com/dajobe/docker-nghttp2
-RUN /build/prepare-build.sh && \
+RUN /build/secure-base.sh && \
+    /build/prepare-build.sh && \
     /build/prepare-php.sh && \
     cd /build/php-$PHP_VERSION && make -j3 && make install && \
     /build/config-php.sh && \

--- a/template/secure-base.sh
+++ b/template/secure-base.sh
@@ -1,0 +1,7 @@
+#!/bin/bash -x
+
+. /build/config-build-env.sh
+
+apt-get update -y
+apt upgrade -y
+


### PR DESCRIPTION
* Changes the base image to not be restricted to the arm64 platform for platform independent building/testing.
* Adds an initial build step to upgrade all system packages to apply security updates.
* Updates GitHub Actions workflow to allow for disabling the cache on manual builds for security updates.