### PR TITLE
fix(php): Updates PHP 8.x Versions to Latest 2023-06-08 Releases (#92)

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -8,7 +8,7 @@ on:
 
 env:
   OLS_VERSION: 1.7.16
-  PHP_STABLE_VERSION: '8.2.6'
+  PHP_STABLE_VERSION: '8.2.7'
   REGISTRY: ghcr.io
 
 jobs:
@@ -17,7 +17,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix: 
-        PHP_VERSION: ['8.0.28', '8.1.19', '8.2.6']
+        PHP_VERSION: ['8.0.29', '8.1.20', '8.2.7']
 
     steps:
       - name: Checkout


### PR DESCRIPTION
* Updates to PHP 8.0.29.
* Updates to PHP 8.1.20
* Updates to PHP 8.2.7.