### PR TITLE
feat(Docker): Adds build support and documentation for more tags (#108)

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -39,6 +39,15 @@ jobs:
           logout: false
 
       # https://github.com/orgs/community/discussions/26625#discussioncomment-3252582
+      - name: Determine OLS Major/Minor Version
+        id: ols-version
+        run: |
+          _0=$(echo ${{ env.OLS_VERSION }} | cut -d. -f1)
+          _1=$(echo ${{ env.OLS_VERSION }} | cut -d. -f2)
+          echo "_0=$_0" >> $GITHUB_OUTPUT
+          echo "_1=$_1" >> $GITHUB_OUTPUT
+
+      # https://github.com/orgs/community/discussions/26625#discussioncomment-3252582
       - name: Determine PHP Major/Minor Version
         id: php-version
         run: |
@@ -61,7 +70,11 @@ jobs:
             PHP_MAJOR_VERSION=${{ steps.php-version.outputs._0 }}
             PHP_MINOR_VERSION=${{ steps.php-version.outputs._1 }}
           push: true
-          tags: ${{ env.REGISTRY }}/ndigitals/openlitespeed:${{ env.OLS_VERSION }}-lsphp${{ steps.php-version.outputs._0 }}${{ steps.php-version.outputs._1 }}
+          tags: |
+            ${{ env.REGISTRY }}/ndigitals/openlitespeed:${{ env.OLS_VERSION }}-lsphp${{ steps.php-version.outputs._0 }}${{ steps.php-version.outputs._1 }}
+            ${{ env.REGISTRY }}/ndigitals/openlitespeed:${{ steps.ols-version.outputs._0 }}.${{ steps.ols-version.outputs._1 }}-lsphp${{ steps.php-version.outputs._0 }}${{ steps.php-version.outputs._1 }}
+            ${{ env.REGISTRY }}/ndigitals/openlitespeed:${{ steps.ols-version.outputs._0 }}-lsphp${{ steps.php-version.outputs._0 }}${{ steps.php-version.outputs._1 }}
+            ${{ env.REGISTRY }}/ndigitals/openlitespeed:lsphp${{ steps.php-version.outputs._0 }}${{ steps.php-version.outputs._1 }}
           no-cache: ${{ github.event_name == 'workflow_dispatch' && true || false }}
           cache-from: type=registry,ref=${{ env.REGISTRY }}/ndigitals/openlitespeed:latest
           cache-to: type=inline
@@ -82,6 +95,9 @@ jobs:
           push: true
           tags: |
             ${{ env.REGISTRY }}/ndigitals/openlitespeed:${{ env.OLS_VERSION }}-lsphp${{ steps.php-version.outputs._0 }}${{ steps.php-version.outputs._1 }}
+            ${{ env.REGISTRY }}/ndigitals/openlitespeed:${{ steps.ols-version.outputs._0 }}.${{ steps.ols-version.outputs._1 }}-lsphp${{ steps.php-version.outputs._0 }}${{ steps.php-version.outputs._1 }}
+            ${{ env.REGISTRY }}/ndigitals/openlitespeed:${{ steps.ols-version.outputs._0 }}-lsphp${{ steps.php-version.outputs._0 }}${{ steps.php-version.outputs._1 }}
+            ${{ env.REGISTRY }}/ndigitals/openlitespeed:lsphp${{ steps.php-version.outputs._0 }}${{ steps.php-version.outputs._1 }}
             ${{ env.REGISTRY }}/ndigitals/openlitespeed:latest
           no-cache: ${{ github.event_name == 'workflow_dispatch' && true || false }}
           cache-from: type=registry,ref=${{ env.REGISTRY }}/ndigitals/openlitespeed:latest

--- a/.github/workflows/test-builds.yml
+++ b/.github/workflows/test-builds.yml
@@ -63,7 +63,7 @@ jobs:
           push: false
           tags: openlitespeed:${{ env.OLS_VERSION }}-lsphp${{ steps.php-version.outputs._0 }}${{ steps.php-version.outputs._1 }}
           no-cache: ${{ github.event_name == 'workflow_dispatch' && true || false }}
-          cache-from: type=registry,ref=${{ env.REGISTRY }}/ndigitals/openlitespeed:latest
+          cache-from: type=registry,ref=${{ env.REGISTRY }}/ndigitals/openlitespeed:${{ env.OLS_VERSION }}-lsphp${{ steps.php-version.outputs._0 }}${{ steps.php-version.outputs._1 }}
           cache-to: type=inline
 
       - name: Test Docker Image

--- a/README.md
+++ b/README.md
@@ -4,7 +4,15 @@
 
 Install a lightweight OpenLiteSpeed container using the Stable version in Debian 11 Linux on arm64.
 
-### Prerequisites
+## Supported tags and respective `Dockerfile` links
+
+- `1.7.18-lsphp82`, `1.7-lsphp82`, `lsphp82`
+- `1.7.18-lsphp81`, `1.7-lsphp81`, `lsphp81`
+- `1.7.18-lsphp80`, `1.7-lsphp80`, `lsphp80`
+- `1.7.17-lsphp82`, `1.7.17-lsphp81`, `1.7.17-lsphp80`
+- `1.7.16-lsphp82`, `1.7.16-lsphp81`, `1.7.16-lsphp80`
+
+## Prerequisites
 
 - [Install Docker](https://www.docker.com/)
 


### PR DESCRIPTION
- Updates the Docker image tagging to add additional tags to allow users to get updates for OpenLiteSpeed but stick to a specific version of PHP.
- Updates Docker image testing to pull correct tagged image for the cache.
- Updates the README to include the listing of available tags.