### PR TITLE
PHP 8.2.11/8.1.24 & Depenedcies Update Release

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -58,7 +58,7 @@ jobs:
 
       # https://github.com/marketplace/actions/build-and-push-docker-images
       - name: Build and Push Docker Image
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@v5
         if: matrix.PHP_VERSION != env.PHP_STABLE_VERSION
         with:
           context: template
@@ -81,7 +81,7 @@ jobs:
 
       # https://github.com/marketplace/actions/build-and-push-docker-images
       - name: Build and Push Docker Image - latest
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@v5
         if: matrix.PHP_VERSION == env.PHP_STABLE_VERSION
         with:
           context: template

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -8,7 +8,7 @@ on:
 
 env:
   OLS_VERSION: 1.7.18
-  PHP_STABLE_VERSION: '8.2.10'
+  PHP_STABLE_VERSION: '8.2.11'
   REGISTRY: ghcr.io
 
 jobs:
@@ -17,7 +17,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix: 
-        PHP_VERSION: ['8.0.30','8.1.23','8.2.10']
+        PHP_VERSION: ['8.0.30','8.1.24','8.2.11']
 
     steps:
       - name: Checkout

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -27,7 +27,7 @@ jobs:
 
       # https://github.com/marketplace/actions/docker-setup-buildx
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v3
 
       # https://github.com/marketplace/actions/docker-login
       - name: Login to GitHub Packages

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -21,7 +21,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0 # Required due to the way Git works, without it this action won't be able to find any or the correct tags
 

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -31,7 +31,7 @@ jobs:
 
       # https://github.com/marketplace/actions/docker-login
       - name: Login to GitHub Packages
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}

--- a/.github/workflows/test-builds.yml
+++ b/.github/workflows/test-builds.yml
@@ -8,7 +8,7 @@ on:
 
 env:
   OLS_VERSION: 1.7.18
-  PHP_STABLE_VERSION: '8.2.10'
+  PHP_STABLE_VERSION: '8.2.11'
   REGISTRY: ghcr.io
 
 jobs:
@@ -17,7 +17,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix: 
-        PHP_VERSION: ['8.0.30','8.1.23','8.2.10']
+        PHP_VERSION: ['8.0.30','8.1.24','8.2.11']
 
     steps:
       - name: Checkout

--- a/.github/workflows/test-builds.yml
+++ b/.github/workflows/test-builds.yml
@@ -27,7 +27,7 @@ jobs:
 
       # https://github.com/marketplace/actions/docker-setup-buildx
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v3
 
       # https://github.com/marketplace/actions/docker-login
       - name: Login to GitHub Packages

--- a/.github/workflows/test-builds.yml
+++ b/.github/workflows/test-builds.yml
@@ -21,7 +21,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0 # Required due to the way Git works, without it this action won't be able to find any or the correct tags
 

--- a/.github/workflows/test-builds.yml
+++ b/.github/workflows/test-builds.yml
@@ -31,7 +31,7 @@ jobs:
 
       # https://github.com/marketplace/actions/docker-login
       - name: Login to GitHub Packages
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}

--- a/.github/workflows/test-builds.yml
+++ b/.github/workflows/test-builds.yml
@@ -49,7 +49,7 @@ jobs:
 
       # https://github.com/marketplace/actions/build-and-push-docker-images
       - name: Build Docker Image
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@v5
         with:
           context: template
           platforms: linux/arm64


### PR DESCRIPTION
- chore(deps): Bump actions/checkout from 3 to 4 (#114)
- chore(deps): Bump docker/setup-buildx-action from 2 to 3 (#116)
- chore(deps): Bump docker/login-action from 2 to 3 (#117)
- chore(deps): Bump docker/build-push-action from 4 to 5 (#118)
- fix(PHP): Upgrades PHP to Latest 8.1 & 8.2 Releases (#120)
