### PR TITLE
fix(acme): Updates the OpenLiteSpeed `docker.conf` for new ACME ECC key default

### DIFF
--- a/template/docker.conf
+++ b/template/docker.conf
@@ -51,8 +51,8 @@ RewriteFile .htaccess
   }
 
   vhssl  {
-    keyFile               /root/.acme.sh/certs/$VH_NAME/$VH_NAME.key
-    certFile              /root/.acme.sh/certs/$VH_NAME/fullchain.cer
+    keyFile               /root/.acme.sh/certs/$VH_NAME_ecc/$VH_NAME.key
+    certFile              /root/.acme.sh/certs/$VH_NAME_ecc/fullchain.cer
     certChain             1
   }
 }


### PR DESCRIPTION
- Fixes the SSL certificate file path, ACME uses ECC as default key.