### PR TITLE
fix(PHP): Upgrades PHP versions to latest stable releases, Upgrades OLS

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -7,9 +7,9 @@ on:
       - main
 
 env:
-  OLS_VERSION: '1.8.3'
-  PHP_STABLE_VERSION: '8.3.21'
-  NODE_STABLE_VERSION: '20'
+  OLS_VERSION: '1.8.4'
+  PHP_STABLE_VERSION: '8.3.24'
+  NODE_STABLE_VERSION: '22'
   REGISTRY: ghcr.io
 
 jobs:
@@ -20,10 +20,10 @@ jobs:
       matrix: 
         PHP_VERSION:
           - '8.0.30'
-          - '8.1.32'
-          - '8.2.28'
-          - '8.3.21'
-          - '8.4.7'
+          - '8.1.33'
+          - '8.2.29'
+          - '8.3.24'
+          - '8.4.11'
         NODE_VERSION:
           - '16'
           - '18'

--- a/.github/workflows/test-builds.yml
+++ b/.github/workflows/test-builds.yml
@@ -7,7 +7,7 @@ on:
       - develop
 
 env:
-  OLS_VERSION: '1.8.3'
+  OLS_VERSION: '1.8.4'
   REGISTRY: ghcr.io
 
 jobs:
@@ -17,10 +17,10 @@ jobs:
       fail-fast: false
       matrix: 
         PHP_VERSION:
-          - '8.1.32'
-          - '8.2.28'
-          - '8.3.21'
-          - '8.4.7'
+          - '8.1.33'
+          - '8.2.29'
+          - '8.3.24'
+          - '8.4.11'
         NODE_VERSION:
           - '18'
           - '20'

--- a/README.md
+++ b/README.md
@@ -6,20 +6,50 @@ Install a lightweight OpenLiteSpeed container using the Latest version in Debian
 
 ## Supported tags
 
-- `1.8.3-lsphp83-node20`, `1.8.3-lsphp83`, `1.8-lsphp83-node20`, `1.8-lsphp83`, `1-lsphp83-node20`, `1-lsphp83`, `lsphp83-node20`, `lsphp83`
-- `1.8.3-lsphp83-node18`, `1.8-lsphp83-node18`, `1-lsphp83-node18`, `lsphp83-node18`
-- `1.8.3-lsphp83-node16`, `1.8-lsphp83-node16`, `1-lsphp83-node16`, `lsphp83-node16`
-- `1.8.3-lsphp82-node20`, `1.8.3-lsphp82`, `1.8-lsphp82-node20`, `1.8-lsphp82`, `1-lsphp82-node20`, `1-lsphp82`, `lsphp82-node20`, `lsphp82`
-- `1.8.3-lsphp82-node18`, `1.8-lsphp82-node18`, `1-lsphp82-node18`, `lsphp82-node18`
-- `1.8.3-lsphp82-node16`, `1.8-lsphp82-node16`, `1-lsphp82-node16`, `lsphp82-node16`
-- `1.8.3-lsphp81-node20`, `1.8.3-lsphp81`, `1.8-lsphp81-node20`, `1.8-lsphp81`, `1-lsphp81-node20`, `1-lsphp81`, `lsphp81-node20`, `lsphp81`
-- `1.8.3-lsphp81-node18`, `1.8-lsphp81-node18`, `1-lsphp81-node18`, `lsphp81-node18`
-- `1.8.3-lsphp81-node16`, `1.8-lsphp81-node16`, `1-lsphp81-node16`, `lsphp81-node16`
-- `1.8.3-lsphp80-node20`, `1.8.3-lsphp80`, `1.8-lsphp80-node20`, `1.8-lsphp80`, `1-lsphp80-node20`, `1-lsphp80`, `lsphp80-node20`, `lsphp80`
-- `1.8.3-lsphp80-node18`, `1.8-lsphp80-node18`, `1-lsphp80-node18`, `lsphp80-node18`
-- `1.8.3-lsphp80-node16`, `1.8-lsphp80-node16`, `1-lsphp80-node16`, `lsphp80-node16`
+- `1.8.4-lsphp84-node22`, `1.8.4-lsphp84`, `1.8-lsphp84-node22`, `1.8-lsphp84`, `1-lsphp84-node22`, `1-lsphp84`, `lsphp84-node22`, `lsphp84`
+- `1.8.4-lsphp84-node20`, `1.8-lsphp84-node20`, `1-lsphp84-node20`, `lsphp84-node20`
+- `1.8.4-lsphp84-node18`, `1.8-lsphp84-node18`, `1-lsphp84-node18`, `lsphp84-node18`
+- `1.8.4-lsphp84-node16`, `1.8-lsphp84-node16`, `1-lsphp84-node16`, `lsphp84-node16`
+- `1.8.4-lsphp83-node22`, `1.8.4-lsphp83`, `1.8-lsphp83-node22`, `1.8-lsphp83`, `1-lsphp83-node22`, `1-lsphp83`, `lsphp83-node22`, `lsphp83`
+- `1.8.4-lsphp83-node20`, `1.8-lsphp83-node20`, `1-lsphp83-node20`, `lsphp83-node20`
+- `1.8.4-lsphp83-node18`, `1.8-lsphp83-node18`, `1-lsphp83-node18`, `lsphp83-node18`
+- `1.8.4-lsphp83-node16`, `1.8-lsphp83-node16`, `1-lsphp83-node16`, `lsphp83-node16`
+- `1.8.4-lsphp82-node22`, `1.8.4-lsphp82`, `1.8-lsphp82-node22`, `1.8-lsphp82`, `1-lsphp82-node22`, `1-lsphp82`, `lsphp82-node22`, `lsphp82`
+- `1.8.4-lsphp82-node20`, `1.8-lsphp82-node20`, `1-lsphp82-node20`, `lsphp82-node20`
+- `1.8.4-lsphp82-node18`, `1.8-lsphp82-node18`, `1-lsphp82-node18`, `lsphp82-node18`
+- `1.8.4-lsphp82-node16`, `1.8-lsphp82-node16`, `1-lsphp82-node16`, `lsphp82-node16`
+- `1.8.4-lsphp81-node22`, `1.8.4-lsphp81`, `1.8-lsphp81-node22`, `1.8-lsphp81`, `1-lsphp81-node22`, `1-lsphp81`, `lsphp81-node22`, `lsphp81`
+- `1.8.4-lsphp81-node20`, `1.8-lsphp81-node20`, `1-lsphp81-node20`, `lsphp81-node20`
+- `1.8.4-lsphp81-node18`, `1.8-lsphp81-node18`, `1-lsphp81-node18`, `lsphp81-node18`
+- `1.8.4-lsphp81-node16`, `1.8-lsphp81-node16`, `1-lsphp81-node16`, `lsphp81-node16`
+- `1.8.4-lsphp80-node22`, `1.8.4-lsphp80`, `1.8-lsphp80-node22`, `1.8-lsphp80`, `1-lsphp80-node22`, `1-lsphp80`, `lsphp80-node22`, `lsphp80`
+- `1.8.4-lsphp80-node20`, `1.8-lsphp80-node20`, `1-lsphp80-node20`, `lsphp80-node20`
+- `1.8.4-lsphp80-node18`, `1.8-lsphp80-node18`, `1-lsphp80-node18`, `lsphp80-node18`
+- `1.8.4-lsphp80-node16`, `1.8-lsphp80-node16`, `1-lsphp80-node16`, `lsphp80-node16`
 
 ## Legacy Tags
+
+- `1.8.3-lsphp84-node22`
+- `1.8.3-lsphp84-node20`
+- `1.8.3-lsphp84-node18`
+- `1.8.3-lsphp84-node16`
+- `1.8.3-lsphp83-node22`
+- `1.8.3-lsphp83-node20`, `1.8.3-lsphp83`
+- `1.8.3-lsphp83-node18`
+- `1.8.3-lsphp83-node16`
+- `1.8.3-lsphp82-node22`
+- `1.8.3-lsphp82-node22`
+- `1.8.3-lsphp82-node20`, `1.8.3-lsphp82`
+- `1.8.3-lsphp82-node18`
+- `1.8.3-lsphp82-node16`
+- `1.8.3-lsphp81-node22`
+- `1.8.3-lsphp81-node20`, `1.8.3-lsphp81`
+- `1.8.3-lsphp81-node18`
+- `1.8.3-lsphp81-node16`
+- `1.8.3-lsphp80-node22`
+- `1.8.3-lsphp80-node20`, `1.8.3-lsphp80`
+- `1.8.3-lsphp80-node18`
+- `1.8.3-lsphp80-node16`
 
 - `1.7.19-lsphp83-node20`, `1.7.19-lsphp83`, `1.7-lsphp83-node20`, `1.7-lsphp83`
 - `1.7.19-lsphp83-node18`, `1.7-lsphp83-node18`

--- a/template/Dockerfile
+++ b/template/Dockerfile
@@ -18,7 +18,7 @@ ARG OLS_ADMIN_PHP_MAJOR_VERSION
 ARG OLS_ADMIN_PHP_MINOR_VERSION
 ARG NODE_VERSION
 
-FROM litespeedtech/openlitespeed:${OLS_VERSION}-lsphp${PHP_MAJOR_VERSION}1 AS ols
+FROM litespeedtech/openlitespeed:${OLS_VERSION}-lsphp${PHP_MAJOR_VERSION}${PHP_MINOR_VERSION} AS ols
 
 FROM debian:11-slim
 
@@ -69,7 +69,7 @@ RUN /build/secure-base.sh && \
 
 RUN mkdir -p /usr/local/lsws/lsphp${PHP_MAJOR_VERSION}${PHP_MINOR_VERSION}/etc/php/${PHP_MAJOR_VERSION}.${PHP_MINOR_VERSION}/
 
-COPY --from=ols ["/usr/local/lsws/lsphp${PHP_MAJOR_VERSION}1/etc/php/${PHP_MAJOR_VERSION}.1/", "/usr/local/lsws/lsphp${PHP_MAJOR_VERSION}${PHP_MINOR_VERSION}/etc/php/${PHP_MAJOR_VERSION}.${PHP_MINOR_VERSION}/"]
+COPY --from=ols ["/usr/local/lsws/lsphp${PHP_MAJOR_VERSION}${PHP_MINOR_VERSION}/etc/php/${PHP_MAJOR_VERSION}.${PHP_MINOR_VERSION}/", "/usr/local/lsws/lsphp${PHP_MAJOR_VERSION}${PHP_MINOR_VERSION}/etc/php/${PHP_MAJOR_VERSION}.${PHP_MINOR_VERSION}/"]
 COPY --from=wp-cli ["/usr/local/bin/wp", "/usr/bin/wp"]
 
 EXPOSE 7080


### PR DESCRIPTION
- Updates README to include OLS 1.8.4, PHP 8.4, & NodeJS 22 tags.
- Updates v8.1 to v8.1.33.
- Updates v8.2 to v8.2.29.
- Updates v8.3 to v8.3.24.
- Updates v8.4 to v8.4.11.
- Updates OLS to 1.8.4.
