### PR TITLE
fix(PHP): Upgrades PHP versions to latest stable releases, Upgrades OLS

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -7,9 +7,9 @@ on:
       - main
 
 env:
-  OLS_VERSION: '1.8.3'
-  PHP_STABLE_VERSION: '8.3.21'
-  NODE_STABLE_VERSION: '20'
+  OLS_VERSION: '1.8.5'
+  PHP_STABLE_VERSION: '8.3.30'
+  NODE_STABLE_VERSION: '22'
   REGISTRY: ghcr.io
 
 jobs:
@@ -19,16 +19,14 @@ jobs:
       fail-fast: false
       matrix: 
         PHP_VERSION:
-          - '8.0.30'
-          - '8.1.32'
-          - '8.2.28'
-          - '8.3.21'
-          - '8.4.7'
+          - '8.2.30'
+          - '8.3.30'
+          - '8.4.17'
         NODE_VERSION:
-          - '16'
           - '18'
           - '20'
           - '22'
+          - '24'
 
     steps:
       - name: Checkout

--- a/.github/workflows/test-builds.yml
+++ b/.github/workflows/test-builds.yml
@@ -7,24 +7,21 @@ on:
       - develop
 
 env:
-  OLS_VERSION: '1.8.3'
+  OLS_VERSION: '1.8.5'
   REGISTRY: ghcr.io
 
 jobs:
   buildx:
-    runs-on: self-hosted
+    runs-on: ubuntu-22.04-arm
     strategy:
       fail-fast: false
       matrix: 
         PHP_VERSION:
-          - '8.1.32'
-          - '8.2.28'
-          - '8.3.21'
-          - '8.4.7'
+          - '8.2.30'
+          - '8.4.17'
         NODE_VERSION:
           - '18'
-          - '20'
-          - '22'
+          - '24'
 
     steps:
       - name: Checkout
@@ -80,14 +77,27 @@ jobs:
       - name: Test Docker Image
         run: |
           IMAGE=openlitespeed:${{ env.OLS_VERSION }}-lsphp${{ steps.php-version.outputs._0 }}${{ steps.php-version.outputs._1 }}-node${{ matrix.NODE_VERSION }}
-          echo -e 'Testing PHP Info Site...'
+          echo -e "::group::Testing PHP Info Site"
+          echo -e '...starting Docker image...'
           ID=$(docker run -d ${IMAGE})
-          sleep 5s
+          echo -e '...waiting for Docker image to startup...'
+          until [[ "`docker inspect -f {{.State.Running}} ${ID}`" == "true" ]]; do
+              sleep 0.1
+          done
+          echo -e '...adding phpinfo test script, and restarting lsws service...'
           docker exec -i ${ID} su -c 'mkdir -p /var/www/vhosts/localhost/html/ && echo "<?php phpinfo();" > /var/www/vhosts/localhost/html/index.php && service lsws restart'
+          until [[ "`docker inspect -f {{.State.Running}} ${ID}`" == "true" ]]; do
+              sleep 0.1
+          done
+          echo -e '...testing HTTP response from within Docker contianer...'
           HTTP=$(docker exec -i ${ID} su -c 'curl -s -o /dev/null -IkL -w "%{http_code}" http://localhost')
+          echo -e '...testing HTTPS response from within Docker contianer...'
           HTTPS=$(docker exec -i ${ID} su -c 'curl -s -o /dev/null -Ik -w "%{http_code}" https://localhost')
+          echo -e '...terminating Docker contianer...'
           docker kill ${ID} &>/dev/null
+          echo -e '...removing Docker container...'
           docker rm ${ID} &>/dev/null
+          echo -e '...validating results...'
           if [[ "${HTTP}" != "200" || "${HTTPS}" != "200" ]]; then
               echo -e '[\u2718] Test failed!'
               echo "http://localhost returned ${HTTP}"
@@ -97,13 +107,23 @@ jobs:
           else
               echo -e '[\u2714] Tests passed!'
           fi
-          echo -e 'Testing OLS Admin Control Panel...'
+          echo -e "::endgroup::"
+          echo -e "::group::Testing OLS Admin Control Panel"
+          echo -e '...starting Docker image...'
           ID=$(docker run -d ${IMAGE})
-          sleep 5s
+          echo -e '...waiting for Docker image to startup...'
+          until [[ "`docker inspect -f {{.State.Running}} ${ID}`" == "true" ]]; do
+              sleep 0.1
+          done
+          echo -e '...testing HTTP response of Admin Control Panel from within Docker contianer...'
           HTTP=$(docker exec -i ${ID} su -c 'curl -s -o /dev/null -IkL -w "%{http_code}" "http://localhost:7080/login.php?timedout=1#view/confMgr.php?m=tp_docker&p=ext"')
+          echo -e '...testing HTTPS response of Admin Control Panel from within Docker contianer...'
           HTTPS=$(docker exec -i ${ID} su -c 'curl -s -o /dev/null -Ik -w "%{http_code}" "https://localhost:7080/login.php?timedout=1#view/confMgr.php?m=tp_docker&p=ext"')
+          echo -e '...terminating Docker contianer...'
           docker kill ${ID} &>/dev/null
+          echo -e '...removing Docker container...'
           docker rm ${ID} &>/dev/null
+          echo -e '...validating results...'
           if [[ "${HTTP}" != "200" || "${HTTPS}" != "200" ]]; then
               echo -e '[\u2718] Test failed!'
               echo "http://localhost returned ${HTTP}"
@@ -115,4 +135,5 @@ jobs:
           fi
           echo -e 'Cleaning Up Test Image...'
           docker rmi ${IMAGE} &>/dev/null
+          echo -e "::endgroup::"
 

--- a/README.md
+++ b/README.md
@@ -6,20 +6,39 @@ Install a lightweight OpenLiteSpeed container using the Latest version in Debian
 
 ## Supported tags
 
-- `1.8.3-lsphp83-node20`, `1.8.3-lsphp83`, `1.8-lsphp83-node20`, `1.8-lsphp83`, `1-lsphp83-node20`, `1-lsphp83`, `lsphp83-node20`, `lsphp83`
-- `1.8.3-lsphp83-node18`, `1.8-lsphp83-node18`, `1-lsphp83-node18`, `lsphp83-node18`
-- `1.8.3-lsphp83-node16`, `1.8-lsphp83-node16`, `1-lsphp83-node16`, `lsphp83-node16`
-- `1.8.3-lsphp82-node20`, `1.8.3-lsphp82`, `1.8-lsphp82-node20`, `1.8-lsphp82`, `1-lsphp82-node20`, `1-lsphp82`, `lsphp82-node20`, `lsphp82`
-- `1.8.3-lsphp82-node18`, `1.8-lsphp82-node18`, `1-lsphp82-node18`, `lsphp82-node18`
-- `1.8.3-lsphp82-node16`, `1.8-lsphp82-node16`, `1-lsphp82-node16`, `lsphp82-node16`
-- `1.8.3-lsphp81-node20`, `1.8.3-lsphp81`, `1.8-lsphp81-node20`, `1.8-lsphp81`, `1-lsphp81-node20`, `1-lsphp81`, `lsphp81-node20`, `lsphp81`
-- `1.8.3-lsphp81-node18`, `1.8-lsphp81-node18`, `1-lsphp81-node18`, `lsphp81-node18`
-- `1.8.3-lsphp81-node16`, `1.8-lsphp81-node16`, `1-lsphp81-node16`, `lsphp81-node16`
-- `1.8.3-lsphp80-node20`, `1.8.3-lsphp80`, `1.8-lsphp80-node20`, `1.8-lsphp80`, `1-lsphp80-node20`, `1-lsphp80`, `lsphp80-node20`, `lsphp80`
-- `1.8.3-lsphp80-node18`, `1.8-lsphp80-node18`, `1-lsphp80-node18`, `lsphp80-node18`
-- `1.8.3-lsphp80-node16`, `1.8-lsphp80-node16`, `1-lsphp80-node16`, `lsphp80-node16`
+- `1.8.5-lsphp84-node22`, `1.8.5-lsphp84`, `1.8-lsphp84-node22`, `1.8-lsphp84`, `1-lsphp84-node22`, `1-lsphp84`, `lsphp84-node22`, `lsphp84`
+- `1.8.5-lsphp84-node20`, `1.8-lsphp84-node20`, `1-lsphp84-node20`, `lsphp84-node20`
+- `1.8.5-lsphp84-node18`, `1.8-lsphp84-node18`, `1-lsphp84-node18`, `lsphp84-node18`
+- `1.8.5-lsphp83-node22`, `1.8.5-lsphp83`, `1.8-lsphp83-node22`, `1.8-lsphp83`, `1-lsphp83-node22`, `1-lsphp83`, `lsphp83-node22`, `lsphp83`
+- `1.8.5-lsphp83-node20`, `1.8-lsphp83-node20`, `1-lsphp83-node20`, `lsphp83-node20`
+- `1.8.5-lsphp83-node18`, `1.8-lsphp83-node18`, `1-lsphp83-node18`, `lsphp83-node18`
+- `1.8.5-lsphp82-node22`, `1.8.5-lsphp82`, `1.8-lsphp82-node22`, `1.8-lsphp82`, `1-lsphp82-node22`, `1-lsphp82`, `lsphp82-node22`, `lsphp82`
+- `1.8.5-lsphp82-node20`, `1.8-lsphp82-node20`, `1-lsphp82-node20`, `lsphp82-node20`
+- `1.8.5-lsphp82-node18`, `1.8-lsphp82-node18`, `1-lsphp82-node18`, `lsphp82-node18`
 
 ## Legacy Tags
+
+- `1.8.3-lsphp84-node22`
+- `1.8.3-lsphp84-node20`
+- `1.8.3-lsphp84-node18`
+- `1.8.3-lsphp84-node16`
+- `1.8.3-lsphp83-node22`
+- `1.8.3-lsphp83-node20`, `1.8.3-lsphp83`
+- `1.8.3-lsphp83-node18`
+- `1.8.3-lsphp83-node16`
+- `1.8.3-lsphp82-node22`
+- `1.8.3-lsphp82-node22`
+- `1.8.3-lsphp82-node20`, `1.8.3-lsphp82`
+- `1.8.3-lsphp82-node18`
+- `1.8.3-lsphp82-node16`
+- `1.8.3-lsphp81-node22`
+- `1.8.3-lsphp81-node20`, `1.8.3-lsphp81`
+- `1.8.3-lsphp81-node18`
+- `1.8.3-lsphp81-node16`
+- `1.8.3-lsphp80-node22`
+- `1.8.3-lsphp80-node20`, `1.8.3-lsphp80`
+- `1.8.3-lsphp80-node18`
+- `1.8.3-lsphp80-node16`
 
 - `1.7.19-lsphp83-node20`, `1.7.19-lsphp83`, `1.7-lsphp83-node20`, `1.7-lsphp83`
 - `1.7.19-lsphp83-node18`, `1.7-lsphp83-node18`

--- a/template/Dockerfile
+++ b/template/Dockerfile
@@ -1,41 +1,43 @@
-ARG OLS_VERSION
-ARG PHP_VERSION
-ARG PHP_MAJOR_VERSION
-ARG PHP_MINOR_VERSION
-ARG OLS_ADMIN_PHP_VERSION
-ARG OLS_ADMIN_PHP_MAJOR_VERSION
-ARG OLS_ADMIN_PHP_MINOR_VERSION
-ARG NODE_VERSION
+ARG OLS_VERSION="1.8.5"
+ARG PHP_VERSION="8.3.30"
+ARG PHP_MAJOR_VERSION="8"
+ARG PHP_MINOR_VERSION="3"
+ARG OLS_ADMIN_PHP_VERSION="8.3.30"
+ARG OLS_ADMIN_PHP_MAJOR_VERSION="8"
+ARG OLS_ADMIN_PHP_MINOR_VERSION="3"
+ARG NODE_VERSION="22"
 
 FROM wordpress:cli-php${PHP_MAJOR_VERSION}.${PHP_MINOR_VERSION} AS wp-cli
 
-ARG OLS_VERSION
-ARG PHP_VERSION
-ARG PHP_MAJOR_VERSION
-ARG PHP_MINOR_VERSION
-ARG OLS_ADMIN_PHP_VERSION
-ARG OLS_ADMIN_PHP_MAJOR_VERSION
-ARG OLS_ADMIN_PHP_MINOR_VERSION
-ARG NODE_VERSION
+ARG OLS_VERSION="1.8.5"
+ARG PHP_VERSION="8.3.30"
+ARG PHP_MAJOR_VERSION="8"
+ARG PHP_MINOR_VERSION="3"
+ARG OLS_ADMIN_PHP_VERSION="8.3.30"
+ARG OLS_ADMIN_PHP_MAJOR_VERSION="8"
+ARG OLS_ADMIN_PHP_MINOR_VERSION="3"
+ARG NODE_VERSION="22"
 
-FROM litespeedtech/openlitespeed:${OLS_VERSION}-lsphp${PHP_MAJOR_VERSION}1 AS ols
+FROM litespeedtech/openlitespeed:${OLS_VERSION}-lsphp${PHP_MAJOR_VERSION}${PHP_MINOR_VERSION} AS ols
 
-FROM debian:11-slim
+FROM debian:bookworm-slim
 
+LABEL org.opencontainers.image.authors="Tim Nolte <support@ndigitals.com>"
 LABEL org.opencontainers.image.url=https://github.com/ndigitals/ols-dockerfiles/pkgs/container/openlitespeed
+LABEL org.opencontainers.image.description="ARM64 builds of the OpenLiteSpeed web server with supported PHP & NodeJS versions"
 LABEL org.opencontainers.image.documentation=https://github.com/ndigitals/ols-dockerfiles/wiki
 LABEL org.opencontainers.image.source=https://github.com/ndigitals/ols-dockerfiles
 LABEL org.opencontainers.image.vendor="Nolte Digital Solutions"
 LABEL org.opencontainers.image.licenses=MIT
 
-ARG OLS_VERSION
-ARG PHP_VERSION
-ARG PHP_MAJOR_VERSION
-ARG PHP_MINOR_VERSION
-ARG OLS_ADMIN_PHP_VERSION
-ARG OLS_ADMIN_PHP_MAJOR_VERSION
-ARG OLS_ADMIN_PHP_MINOR_VERSION
-ARG NODE_VERSION
+ARG OLS_VERSION="1.8.5"
+ARG PHP_VERSION="8.3.30"
+ARG PHP_MAJOR_VERSION="8"
+ARG PHP_MINOR_VERSION="3"
+ARG OLS_ADMIN_PHP_VERSION="8.3.30"
+ARG OLS_ADMIN_PHP_MAJOR_VERSION="8"
+ARG OLS_ADMIN_PHP_MINOR_VERSION="3"
+ARG NODE_VERSION="22"
 
 ENV OLS_VERSION=${OLS_VERSION}
 ENV PHP_VERSION=${PHP_VERSION}
@@ -69,7 +71,7 @@ RUN /build/secure-base.sh && \
 
 RUN mkdir -p /usr/local/lsws/lsphp${PHP_MAJOR_VERSION}${PHP_MINOR_VERSION}/etc/php/${PHP_MAJOR_VERSION}.${PHP_MINOR_VERSION}/
 
-COPY --from=ols ["/usr/local/lsws/lsphp${PHP_MAJOR_VERSION}1/etc/php/${PHP_MAJOR_VERSION}.1/", "/usr/local/lsws/lsphp${PHP_MAJOR_VERSION}${PHP_MINOR_VERSION}/etc/php/${PHP_MAJOR_VERSION}.${PHP_MINOR_VERSION}/"]
+COPY --from=ols ["/usr/local/lsws/lsphp${PHP_MAJOR_VERSION}${PHP_MINOR_VERSION}/etc/php/${PHP_MAJOR_VERSION}.${PHP_MINOR_VERSION}/", "/usr/local/lsws/lsphp${PHP_MAJOR_VERSION}${PHP_MINOR_VERSION}/etc/php/${PHP_MAJOR_VERSION}.${PHP_MINOR_VERSION}/"]
 COPY --from=wp-cli ["/usr/local/bin/wp", "/usr/bin/wp"]
 
 EXPOSE 7080

--- a/template/config-build-env.sh
+++ b/template/config-build-env.sh
@@ -15,7 +15,7 @@ PACKAGES_INSTALLED_LOG="/tmp/packages.lst"
 SETUP_PACKAGES="ca-certificates cron tzdata pkg-config git curl wget"
 
 ## Run time dependencies ##
-RUN_PACKAGES="ca-certificates cron tzdata pkg-config git curl wget openssl mariadb-client libgssapi-krb5-2 libkrb5-3 libexpat1 libxml2 libargon2-1 libenchant-2-2 libpng16-16 libwebp6 libjpeg62-turbo libxpm4 libfreetype6 libonig5 libsodium23 libxslt1.1 libzip4 libzstd1 liblz4-1 libcurl4 imagemagick libc-client2007e libmemcached11 libdbd-freetds freetds-bin procps libatomic1 net-tools less libjpeg-turbo-progs optipng gifsicle zip unzip libyajl2 libpcre2-posix2 libpcre++0v5 liblmdb0 libgeoip1 ruby-full gnupg2 nodejs yarn mmdb-bin lua-mmdb brotli libbrotli1 liblua5.2-0 lua5.2 ssdeep libldap-2.4-2 libldap-common libssh2-1 libsasl2-2 libsasl2-modules libsasl2-modules-db libnghttp2-14 libpsl5 librtmp1 publicsuffix webp"
+RUN_PACKAGES="ca-certificates cron tzdata pkg-config git curl wget openssl mariadb-client libgssapi-krb5-2 libkrb5-3 libexpat1 libxml2 libargon2-1 libenchant-2-2 libpng16-16 libwebp7 libjpeg62-turbo libxpm4 libfreetype6 libonig5 libsodium23 libxslt1.1 libzip4 libzstd1 liblz4-1 libcurl4 imagemagick libc-client2007e libmemcached11 libdbd-freetds freetds-bin procps libatomic1 net-tools less libjpeg-turbo-progs optipng gifsicle zip unzip libyajl2 libpcre2-posix3 libpcre3 libpcrecpp0v5 liblmdb0 libgeoip1 ruby-full gnupg2 nodejs yarn mmdb-bin lua-mmdb brotli libbrotli1 liblua5.2-0 lua5.2 ssdeep libldap-2.5-0 libldap-common libssh2-1 libsasl2-2 libsasl2-modules libsasl2-modules-db libnghttp2-14 libpsl5 librtmp1 publicsuffix webp"
 
 ## Build time dependencies ##
 
@@ -23,10 +23,10 @@ RUN_PACKAGES="ca-certificates cron tzdata pkg-config git curl wget openssl maria
 BUILD_PACKAGES="build-essential"
 
 # OLS build required packages
-BUILD_PACKAGES="$BUILD_PACKAGES cmake g++ autoconf automake libtool flex bison gdb libgeoip-dev liblmdb-dev libyajl-dev libpcre++-dev libmaxminddb-dev liblualib50-dev liblua50-dev libudns-dev libbrotli-dev libssl-dev zlib1g-dev liblua5.2-dev libcurl4-openssl-dev libexpat1-dev libcurlpp-dev libcurlpp0 libidn11-dev libkrb5-dev libldap2-dev librtmp-dev libssh2-1-dev"
+BUILD_PACKAGES="$BUILD_PACKAGES cmake g++ autoconf automake libtool flex bison gdb libgeoip-dev liblmdb-dev libyajl-dev libpcre3-dev libmaxminddb-dev libudns-dev libbrotli-dev libssl-dev zlib1g-dev liblua5.2-dev libcurl4-openssl-dev libexpat1-dev libcurlpp-dev libcurlpp0 libidn11-dev libkrb5-dev libldap2-dev librtmp-dev libssh2-1-dev"
 
 # PHP building required packages
-BUILD_PACKAGES="$BUILD_PACKAGES libdb5.3-dev krb5-multidev re2c libxml2-dev libbz2-dev libjpeg-dev libfreetype6-dev libgmp3-dev libpng-dev libxpm-dev libc-client2007e-dev libenchant-2-dev libsasl2-dev libc-client2007e-dev libldb-dev libmcrypt-dev libmhash-dev freetds-dev zlib1g-dev libpq-dev libmariadb-dev-compat libmariadb-dev libncurses5-dev libpcre2-dev libpcre3-dev unixodbc-dev libsqlite3-dev libaspell-dev libreadline6-dev librecode-dev libsnmp-dev libtidy-dev libxslt-dev libonig-dev libzip-dev libwebp-dev freetds-dev libpspell-dev libedit-dev libsodium-dev libargon2-dev libvarnishapi-dev libmagickwand-dev libmagickcore-dev libmemcached-dev libzstd-dev liblz4-dev libyaml-dev libffi-dev"
+BUILD_PACKAGES="$BUILD_PACKAGES libdb5.3-dev krb5-multidev re2c libxml2-dev libbz2-dev libjpeg-dev libjpeg62-turbo-dev libfreetype6-dev libgmp3-dev libpng-dev libxpm-dev libc-client2007e-dev libenchant-2-dev libsasl2-dev libc-client2007e-dev libldb-dev libmcrypt-dev libmhash-dev freetds-dev zlib1g-dev libpq-dev libmariadb-dev-compat libmariadb-dev libncurses5-dev libpcre2-dev libpcre3-dev unixodbc-dev libsqlite3-dev libaspell-dev libreadline6-dev librecode-dev libsnmp-dev libtidy-dev libxslt-dev libonig-dev libzip-dev libwebp-dev freetds-dev libpspell-dev libedit-dev libsodium-dev libargon2-dev libvarnishapi-dev libmagickwand-dev libmagickcore-dev libmemcached-dev libzstd-dev liblz4-dev libyaml-dev libffi-dev"
 
 # apt-get remove --allow-remove-essential enters an infinite loop of
 # pam errors with this package


### PR DESCRIPTION
- Updates README to include OLS 1.8.5, PHP 8.4, NodeJS 22 & 24 tags.
- Updates v8.1 to v8.1.34.
- Updates v8.2 to v8.2.30.
- Updates v8.3 to v8.3.30.
- Updates v8.4 to v8.4.17.
- Updates OLS to 1.8.5.
- Drops PHP 8.0/8.1 & NodeJS 16.
- Updates Linux to Bookworm/12.
